### PR TITLE
Makefile improvements: DESTDIR, PREFIX, CXX, all target, .PHONY

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+DESTDIR=
+PREFIX=/usr/local
+
 dylibbundler:
 	g++ -c -I./src ./src/Settings.cpp -o ./Settings.o
 	g++ -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
@@ -11,5 +14,5 @@ clean:
 	rm -f ./dylibbundler
 	
 install: dylibbundler
-	cp ./dylibbundler /usr/local/bin/dylibbundler
-	chmod 775 /usr/local/bin/dylibbundler
+	cp ./dylibbundler $(DESTDIR)$(PREFIX)/bin/dylibbundler
+	chmod 775 $(DESTDIR)$(PREFIX)/bin/dylibbundler

--- a/makefile
+++ b/makefile
@@ -18,3 +18,5 @@ clean:
 install: dylibbundler
 	cp ./dylibbundler $(DESTDIR)$(PREFIX)/bin/dylibbundler
 	chmod 775 $(DESTDIR)$(PREFIX)/bin/dylibbundler
+
+.PHONY: all clean install

--- a/makefile
+++ b/makefile
@@ -4,12 +4,12 @@ PREFIX=/usr/local
 all: dylibbundler
 
 dylibbundler:
-	g++ -c -I./src ./src/Settings.cpp -o ./Settings.o
-	g++ -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
-	g++ -c -I./src ./src/Dependency.cpp -o ./Dependency.o
-	g++ -c -I./src ./src/main.cpp -o ./main.o
-	g++ -c -I./src ./src/Utils.cpp -o ./Utils.o
-	g++ -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
+	$(CXX) -c -I./src ./src/Settings.cpp -o ./Settings.o
+	$(CXX) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
+	$(CXX) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
+	$(CXX) -c -I./src ./src/main.cpp -o ./main.o
+	$(CXX) -c -I./src ./src/Utils.cpp -o ./Utils.o
+	$(CXX) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
 
 clean:
 	rm -f *.o

--- a/makefile
+++ b/makefile
@@ -1,6 +1,8 @@
 DESTDIR=
 PREFIX=/usr/local
 
+all: dylibbundler
+
 dylibbundler:
 	g++ -c -I./src ./src/Settings.cpp -o ./Settings.o
 	g++ -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o


### PR DESCRIPTION
This pull request makes a number of improvements to the makefile, which [MacPorts has been using for over four years](http://trac.macports.org/browser/trunk/dports/devel/dylibbundler/files/patch-makefile.diff?rev=78576):

* Introduces a `PREFIX` variable so that the user can indicate where it should be installed
* Introduced a `DESTDIR` variable so that the installation can be staged to another directory first
* Introduces an `all` target, for clarity
* Declares all non-file targets to be `.PHONY`
* Makes use of the `CXX` variable so that the user can change the compiler
