### PR TITLE
Add missing cstdio include - fixes  #4

### DIFF
--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <locale>
 #include "Dependency.h"
 #include <iostream>
+#include <cstdio>
 #include <cstdlib>
 #include <sys/param.h>
 #include "Utils.h"

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "DylibBundler.h"
 #include <iostream>
+#include <cstdio>
 #include <cstdlib>
 #include "Utils.h"
 #include "Settings.h"

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <unistd.h>
 #include <iostream>
+#include <cstdio>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <cstdio>
 #include <vector>
 #include "Settings.h"
 


### PR DESCRIPTION
This fixes  #4, otherwise stdout is undefined and compilation fails on linux with gcc and clang.