### PR TITLE
Fix data storage problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
   include:
     - osx_image: xcode9.2
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/opt/wxmac/lib/:/usr/local/Cellar/jack/0.125.0_2/lib:-L/usr/local/lib"
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/lib"
 
     - osx_image: xcode9.2
       env:
-        - MATRIX_EVAL="CC=gcc && CXX=g++ && EXTRA_BREW=gcc && DYLD_LIBRARY_PATH=":/usr/local/opt/wxmac/lib/:/usr/local/Cellar/jack/0.125.0_2/lib:-L/usr/local/lib"
+        - MATRIX_EVAL="CC=gcc && CXX=g++ && EXTRA_BREW=gcc && DYLD_LIBRARY_PATH=":/usr/local/lib"
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ before_install:
     - mkdir -p config lib/rtmidi/config
     - touch config/config.rpath lib/rtmidi/config/config.rpath
     - eval "${MATRIX_EVAL}"
-    - pwd
-    - ls
-    - if test "$TRAVIS_OS_NAME" = osx ; then  brew update ; fi
-    - if test "$TRAVIS_OS_NAME" = osx ; then brew upgrade boost ; fi
     - if test "$TRAVIS_OS_NAME" = osx ; then rm -rf /usr/local/include/c++ ; fi # fix broken gcc installation
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 os: osx
 osx_image: xcode9.2
 env:
-  - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/lib"
+  - MATRIX_EVAL="DYLD_LIBRARY_PATH=":/usr/local/lib"
 
 before_install:
     - mkdir -p config lib/rtmidi/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+git:
+  depth: 1
+branches:
+  except:
+    - /(?i:appveyor)/
+language: c++
+compiler:
+  - gcc
+  - clang
+os: osx
+matrix:
+  include:
+    - osx_image: xcode9.2
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/opt/wxmac/lib/:/usr/local/Cellar/jack/0.125.0_2/lib:-L/usr/local/lib"
+
+    - osx_image: xcode9.2
+      env:
+        - MATRIX_EVAL="CC=gcc && CXX=g++ && EXTRA_BREW=gcc && DYLD_LIBRARY_PATH=":/usr/local/opt/wxmac/lib/:/usr/local/Cellar/jack/0.125.0_2/lib:-L/usr/local/lib"
+
+
+
+
+before_install:
+    - mkdir -p config lib/rtmidi/config
+    - touch config/config.rpath lib/rtmidi/config/config.rpath
+    - eval "${MATRIX_EVAL}"
+    - pwd
+    - ls
+    - if test "$TRAVIS_OS_NAME" = osx ; then  brew update ; fi
+    - if test "$TRAVIS_OS_NAME" = osx ; then brew upgrade boost ; fi
+    - if test "$TRAVIS_OS_NAME" = osx ; then rm -rf /usr/local/include/c++ ; fi # fix broken gcc installation
+
+script:
+    - if test "$TRAVIS_OS_NAME" = osx ; then echo "DYLD_LIBRARY_PATH = $DYLD_LIBRARY_PATH" ; fi ;
+    - if test "$TRAVIS_OS_NAME" = osx ; then echo "DYLD_FALLBACK_FRAMEWORK_PATH = $DYLD_FALLBACK_FRAMEWORK_PATH" ; fi ;
+    - if test "$TRAVIS_OS_NAME" = osx ; then make install &&  make tests ; fi ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,9 @@ compiler:
   - gcc
   - clang
 os: osx
-matrix:
-  include:
-    - osx_image: xcode9.2
-      env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/lib"
-
-    - osx_image: xcode9.2
-      env:
-        - MATRIX_EVAL="CC=gcc && CXX=g++ && EXTRA_BREW=gcc && DYLD_LIBRARY_PATH=":/usr/local/lib"
-
-
-
+osx_image: xcode9.2
+env:
+  - MATRIX_EVAL="CC=clang && CXX=clang++ && EXTRA_BREW= && DYLD_LIBRARY_PATH=":/usr/local/lib"
 
 before_install:
     - mkdir -p config lib/rtmidi/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,16 @@ script:
     - if test "$TRAVIS_OS_NAME" = osx ; then echo "DYLD_LIBRARY_PATH = $DYLD_LIBRARY_PATH" ; fi ;
     - if test "$TRAVIS_OS_NAME" = osx ; then echo "DYLD_FALLBACK_FRAMEWORK_PATH = $DYLD_FALLBACK_FRAMEWORK_PATH" ; fi ;
     - if test "$TRAVIS_OS_NAME" = osx ; then make install &&  make tests ; fi ;
+    - mkdir -p public/$CC
+    - if test "$TRAVIS_OS_NAME" = osx ; then cp dylibbundler public/$CC ; fi ;
+
+deploy:
+	- provider: pages
+	  skip_cleanup: true
+	  local-dir: public
+	  branch:	gh-pages
+	  keep-history: true
+	  github-token: $GITHUB_TOKEN
+	  verbose: true
+	  on:
+		branch: master

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 DESTDIR=
 PREFIX=/usr/local
-CXXFLAGS = -O1 -g \ 
+CXXFLAGS = -O1 -g \
 	-fsanitize=address \
 	-fno-omit-frame-pointer \
 	-fno-optimize-sibling-calls
@@ -18,7 +18,7 @@ dylibbundler:
 clean:
 	rm -f *.o
 	rm -f ./dylibbundler
-	
+
 install: dylibbundler
 	cp ./dylibbundler $(DESTDIR)$(PREFIX)/bin/dylibbundler
 	chmod 775 $(DESTDIR)$(PREFIX)/bin/dylibbundler

--- a/makefile
+++ b/makefile
@@ -1,15 +1,19 @@
 DESTDIR=
 PREFIX=/usr/local
+CXXFLAGS = -O1 -g \ 
+	-fsanitize=address \
+	-fno-omit-frame-pointer \
+	-fno-optimize-sibling-calls
 
 all: dylibbundler
 
 dylibbundler:
-	$(CXX) -c -I./src ./src/Settings.cpp -o ./Settings.o
-	$(CXX) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
-	$(CXX) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
-	$(CXX) -c -I./src ./src/main.cpp -o ./main.o
-	$(CXX) -c -I./src ./src/Utils.cpp -o ./Utils.o
-	$(CXX) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
+	$(CXX) $(CXXFLAGS) -c -I./src ./src/Settings.cpp -o ./Settings.o
+	$(CXX) $(CXXFLAGS) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
+	$(CXX) $(CXXFLAGS) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
+	$(CXX) $(CXXFLAGS) -c -I./src ./src/main.cpp -o ./main.o
+	$(CXX) $(CXXFLAGS) -c -I./src ./src/Utils.cpp -o ./Utils.o
+	$(CXX) $(CXXFLAGS) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
 
 clean:
 	rm -f *.o

--- a/makefile
+++ b/makefile
@@ -34,4 +34,14 @@ install: dylibbundler
 	cp ./dylibbundler $(DESTDIR)$(PREFIX)/bin/dylibbundler
 	chmod 775 $(DESTDIR)$(PREFIX)/bin/dylibbundler
 
+tests: link_boost_filesystem dylibbundler
+	mkdir -p test_output/test1/Contents/MacOS
+	cp link_boost_filesystem test_output/test1/Contents/MacOS
+	echo | ./dylibbundler -b -x test_output/test1/Contents/MacOS/link_boost_filesystem \
+		-p @executable_path/../libs/ \
+		-cd -od -d test_output/test1/Contents/libs
+
+link_boost_filesystem: tests/link_boost_filesystem.cpp
+	$(CXX) $(CXXFLAGS) -I./src -lboost_filesystem -lboost_system "$<" -o "$@"
+
 .PHONY: all clean install

--- a/makefile
+++ b/makefile
@@ -6,13 +6,24 @@ CXXFLAGS = -O1 -g \
 	-fno-optimize-sibling-calls
 
 all: dylibbundler
+HEADERS =  src/Settings.h src/Utils.h src/Dependency.h src/DylibBundler.h
 
-dylibbundler:
+Settings.o: src/Settings.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c -I./src ./src/Settings.cpp -o ./Settings.o
+
+DylibBundler.o: src/DylibBundler.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
+
+Dependency.o: src/Dependency.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
+
+main.o: src/main.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c -I./src ./src/main.cpp -o ./main.o
+
+Utils.o: src/Utils.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c -I./src ./src/Utils.cpp -o ./Utils.o
+
+dylibbundler: Settings.o DylibBundler.o Dependency.o main.o Utils.o
 	$(CXX) $(CXXFLAGS) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
 
 clean:

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -182,11 +182,11 @@ void Dependency::print()
         std::cout << "     symlink --> " << symlinks[n].c_str() << std::endl;;
 }
 
-std::string Dependency::getInstallPath()
+std::string Dependency::getInstallPath() const
 {
     return Settings::destFolder() + new_name;
 }
-std::string Dependency::getInnerPath()
+std::string Dependency::getInnerPath() const
 {
     return Settings::inside_lib_path() + new_name;
 }
@@ -209,7 +209,7 @@ bool Dependency::mergeIfSameAs(Dependency& dep2)
     return false;
 }
 
-void Dependency::copyYourself()
+void Dependency::copyYourself() const
 {
     copyFile(getOriginalPath(), getInstallPath());
     

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -149,11 +149,11 @@ Dependency::Dependency(std::string path)
             std::cin >> buffer;
             prefix = buffer;
             std::cout << std::endl;
-            
-            if(prefix.compare("quit")==0) exit(1);
-            
+
+            if(std::cin.eof() || std::cin.fail() || prefix.compare("quit")==0) exit(1);
+
             if( !prefix.empty() && prefix[ prefix.size()-1 ] != '/' ) prefix += "/";
-            
+
             if( !fileExists( prefix+filename ) )
             {
                 std::cerr << (prefix+filename) << " does not exist. Try again" << std::endl;

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -218,16 +218,28 @@ void Dependency::copyYourself() const
     }
 }
 
-void Dependency::fixFileThatDependsOnMe(const std::string & file,
+void Dependency::fixFilesThatDependOnMe(DependencyMap& deps) const {
+	for (filenamelist::const_iterator i = dependents.begin();
+	     i!= dependents.end(); ++i) {
+		DependencyMap::iterator j = deps.find(Dependency(i->second,i->first));
+		if (j != deps.end()) {
+			fixFileThatDependsOnMe(*j, i->first);
+		} else {
+			std::cerr  << "\n\nInternal error : lost track of dependencies of file " << i->second << std::endl;
+		}
+	}
+}
+
+void Dependency::fixFileThatDependsOnMe(const Dependency & file,
 					const std::string & symlink) const
 {
     // for main lib file
     std::string command = std::string("install_name_tool -change ") +
-	    symlink + " " + getInnerPath() + " " + file;
+	    symlink + " " + getInnerPath() + " " + file.getInstallPath();
 
     if( systemp( command ) != 0 )
     {
-        std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file << std::endl;
+	    std::cerr << "\n\nError : An error occured while trying to fix depencies of " << file.getOriginalPath() << std::endl;
         exit(1);
     }
 

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -219,7 +219,7 @@ void Dependency::copyYourself() const
 }
 
 void Dependency::fixFileThatDependsOnMe(const std::string & file,
-					const std::string & symlink)
+					const std::string & symlink) const
 {
     // for main lib file
     std::string command = std::string("install_name_tool -change ") +

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -92,11 +92,23 @@ Dependency::Dependency(std::string path,
     char original_file_buffer[PATH_MAX];
     std::string original_file;
 
+    original_file = path;
+
+    size_t pos = original_file.find("@loader_path/");
+    if (pos  != std::string::npos) {
+	    size_t starting_dir_end = dependent.rfind("/");
+	    if (starting_dir_end != std::string::npos) {
+		    original_file.replace(pos,pos+13,
+					  dependent.substr(0,starting_dir_end+1));
+	    } else {
+		    original_file.replace(pos,pos+13,"./");
+	    }
+    }
+
     //TODO: deal with @... paths
-    if (not realpath(rtrim(path).c_str(), original_file_buffer))
+    if (not realpath(rtrim(original_file).c_str(), original_file_buffer))
     {
         std::cerr << "\n/!\\ WARNING : Cannot resolve path '" << path.c_str() << "'" << std::endl;
-        original_file = path;
     }
     else
     {

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -121,7 +121,8 @@ Dependency::Dependency(std::string path,
 
     filename = stripPrefix(original_file);
     prefix = original_file.substr(0, original_file.rfind("/")+1);
-    addSymlink(path,dependent);
+    if (path != dependent)
+	    addSymlink(path,dependent);
 
 
 

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -63,9 +63,9 @@ public:
 
     void copyYourself() const;
     void fixFileThatDependsOnMe(const std::string & file,
-				const std::string & symlink);
-    void fixFilesThatDependOnMe() {
-	    for (filenamelist::iterator i = dependents.begin();
+				const std::string & symlink) const;
+    void fixFilesThatDependOnMe() const {
+	    for (filenamelist::const_iterator i = dependents.begin();
 		 i!= dependents.end(); ++i) {
 		    fixFileThatDependsOnMe(i->second, i->first);
 	    }

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -56,7 +56,7 @@ public:
 
     void addSymlink(const std::string & symlink,
 		    const std::string & dependent) {
-	    dependents.emplace(symlink,dependent);
+	    dependents.insert(std::pair<std::string,std::string>(symlink,dependent));
     }
     filenamelist::const_iterator dependentsBegin() { return dependents.begin(); }
     filenamelist::const_iterator dependentsEnd() { return dependents.end(); }

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -41,19 +41,18 @@ class Dependency
 public:
     Dependency(std::string path);
 
-    void print();
+    void print() const;
 
     std::string getOriginalFileName() const{ return filename; }
     std::string getOriginalPath() const{ return prefix+filename; }
-    std::string getInstallPath();
-    std::string getInnerPath();
-        
     void addSymlink(std::string s);
     int getSymlinkAmount() const{ return symlinks.size(); }
 
     std::string getSymlink(const int i) const{ return symlinks[i]; }
     std::string getPrefix() const{ return prefix; }
 
+    std::string getInstallPath() const;
+    std::string getInnerPath() const;
     void copyYourself();
     void fixFileThatDependsOnMe(std::string file);
     

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -1,4 +1,4 @@
-/*
+/*  -*- C++ -*-
 The MIT License (MIT)
 
 Copyright (c) 2014 Marianne Gagnon
@@ -28,6 +28,11 @@ THE SOFTWARE.
 
 #include <string>
 #include <map>
+#include <set>
+
+class Dependency;
+typedef std::set<Dependency> DependencyMap;
+
 
 class Dependency
 {
@@ -62,15 +67,9 @@ public:
     filenamelist::const_iterator dependentsEnd() { return dependents.end(); }
 
     void copyYourself() const;
-    void fixFileThatDependsOnMe(const std::string & file,
+    void fixFileThatDependsOnMe(const Dependency & file,
 				const std::string & symlink) const;
-    void fixFilesThatDependOnMe() const {
-	    for (filenamelist::const_iterator i = dependents.begin();
-		 i!= dependents.end(); ++i) {
-		    fixFileThatDependsOnMe(i->second, i->first);
-	    }
-    }
-
+    void fixFilesThatDependOnMe(DependencyMap& deps) const;
     void merge(const Dependency& dep2) {
 	dependents.insert(dep2.dependents.begin(),
 			  dep2.dependents.end());

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -114,6 +114,8 @@ void collectDependencies(std::string filename)
         if (newlibrary[0] != '\t') continue; // only lines beginning with a tab interest us
         if (newlibrary.find(".framework") != std::string::npos ) continue;
 	// Ignore frameworks, we can not handle them
+        if (newlibrary.find("@rpath") != std::string::npos ) continue;
+	// Ignore @rpath, we can not handle it.
 
 	// trim useless info, keep only library name
 	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
@@ -148,6 +150,7 @@ void collectSubDependencies()
             {
                 if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
                 if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
+                if( lines[n].find("@rpath") != std::string::npos ) continue; //Ignore @rpath, we can not handle them
 
 		std::cout <<  (deps[m].getOriginalPath())
 			  << " -> "

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -26,38 +26,47 @@ THE SOFTWARE.
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
+#include <set>
+#include <queue>
 #include "Utils.h"
 #include "Settings.h"
 #include "Dependency.h"
 
 
-std::vector<Dependency> deps;
+typedef std::set<Dependency> DependencyMap;
+DependencyMap deps;
+std::queue <std::string> openDeps;
 
+
+void addOpenDeps(const std::string & path)
+{
+	openDeps.push(path);
+	deps.emplace(path,"");
+}
+
+#if 0
 void changeLibPathsOnFile(std::string file_to_fix)
 {
     std::cout << "\n* Fixing dependencies on " << file_to_fix.c_str() << std::endl;
-    
-    const int dep_amount = deps.size();
-    for(int n=0; n<dep_amount; n++)
-    {
-        deps[n].fixFileThatDependsOnMe(file_to_fix);
-    }
+    deps[file_to_fix].fixFilesThatDependOnMe();
 }
+#endif
 
-void addDependency(std::string path)
+
+Dependency & addDependency(const std::string & path,
+			   const std::string & dependent)
 {
-    Dependency dep(path);
-    
-    // we need to check if this library was already added to avoid duplicates
-    const int dep_amount = deps.size();
-    for(int n=0; n<dep_amount; n++)
-    {
-        if(dep.mergeIfSameAs(deps[n])) return;
-    }
-    
-    if(!Settings::isPrefixBundled(dep.getPrefix())) return;
-    
-    deps.push_back(dep);
+    Dependency dep(path,dependent);
+
+    DependencyMap::iterator pos = deps.find(dep);
+    if (pos == deps.end()) {
+	    pos = deps.insert(dep).first;
+	    if(Settings::isPrefixBundled(dep.getPrefix()))
+		    openDeps.push(dep.getOriginalPath());
+
+    } else
+	    const_cast<Dependency &>(*pos).merge(dep);
+    return const_cast<Dependency &>(*pos);
 }
 
 /*
@@ -74,76 +83,97 @@ void collectDependencies(std::string filename, std::vector<std::string>& lines)
         std::cerr << "Cannot find file " << filename << " to read its dependencies" << std::endl;
         exit(1);
     }
-    
+
     // split output
     tokenize(output, "\n", &lines);
 }
 
-
+// copying the string is ok here, since the original might not be stable.
 void collectDependencies(std::string filename)
 {
+    DependencyMap::iterator d = deps.find(Dependency(filename,""));
+    if (d == deps.end()) {
+	    std::cerr << "Internal error: Dependency " << filename << " is not initialized" << std::endl;
+	    exit(1);
+    }
+    Dependency & dep = const_cast<Dependency &>(*d);
+    filename = dep.getOriginalPath();
+
     std::vector<std::string> lines;
     collectDependencies(filename, lines);
-       
+
     std::cout << "."; fflush(stdout);
-    
+
+    std::string newlibrary;
     const int line_amount = lines.size();
     for(int n=0; n<line_amount; n++)
     {
+	newlibrary = lines[n];
         std::cout << "."; fflush(stdout);
-        if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
-        if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
-        
-	std::cout <<  filename
+	if (newlibrary.empty()) continue; // ignore empty lines
+        if (newlibrary[0] != '\t') continue; // only lines beginning with a tab interest us
+        if (newlibrary.find(".framework") != std::string::npos ) continue;
+	// Ignore frameworks, we can not handle them
+
+	// trim useless info, keep only library name
+	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
+	std::cout << filename
 		  << " -> "
-		  << lines[n].substr(1, lines[n].rfind(" (") - 1) << std::endl;
-        addDependency( // trim useless info, keep only library name
-                       lines[n].substr(1, lines[n].rfind(" (") - 1)
-                       );
+		  << newlibrary << std::endl;
+	addDependency(newlibrary,filename);
     }
 }
 void collectSubDependencies()
 {
     // print status to user
     int dep_amount = deps.size();
-    
+
     // recursively collect each dependencie's dependencies
-    while(true)
+    while(!openDeps.empty())
     {
+	    collectDependencies(openDeps.front());
+	    openDeps.pop();
+    }
+#if 0
+#if 0
         dep_amount = deps.size();
         for(int m=0; m<dep_amount; m++)
         {
             std::cout << "."; fflush(stdout);
             std::vector<std::string> lines;
             collectDependencies(deps[m].getOriginalPath(), lines);
-            
+
             const int line_amount = lines.size();
             for(int n=0; n<line_amount; n++)
             {
                 if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
                 if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
-                
+
 		std::cout <<  (deps[m].getOriginalPath())
 			  << " -> "
 			  << lines[n].substr(1, lines[n].rfind(" (") - 1)<< std::endl;
                 addDependency( // trim useless info, keep only library name
-                               lines[n].substr(1, lines[n].rfind(" (") - 1) 
+                               lines[n].substr(1, lines[n].rfind(" (") - 1)
                                );
             }//next
+#else
+	    collectDependencies(deps[m].getOriginalPath());
+#endif
         }//next
-        
+
         if(deps.size() == dep_amount) break; // no more dependencies were added on this iteration, stop searching
     }
+#endif
 }
 
 void createDestDir()
 {
     std::string dest_folder = Settings::destFolder();
     std::cout << "* Checking output directory " << dest_folder.c_str() << std::endl;
-    
+
     // ----------- check dest folder stuff ----------
     bool dest_exists = fileExists(dest_folder);
-    
+
     if(dest_exists and Settings::canOverwriteDir())
     {
         std::cout << "* Erasing old output directory " << dest_folder.c_str() << std::endl;
@@ -155,10 +185,10 @@ void createDestDir()
         }
         dest_exists = false;
     }
-    
+
     if(!dest_exists)
     {
-        
+
         if(Settings::canCreateDir())
         {
             std::cout << "* Creating output directory " << dest_folder.c_str() << std::endl;
@@ -175,35 +205,30 @@ void createDestDir()
             exit(1);
         }
     }
-    
+
 }
 
 void doneWithDeps_go()
 {
     std::cout << std::endl;
-    const int dep_amount = deps.size();
-    // print info to user
-    for(int n=0; n<dep_amount; n++)
-    {
-        deps[n].print();
+    for (DependencyMap::iterator i = deps.begin();
+	 i != deps.end(); ++i) {
+        i->print();
     }
     std::cout << std::endl;
-    
+
     // copy files if requested by user
     if(Settings::bundleLibs())
     {
         createDestDir();
-        
-        for(int n=0; n<dep_amount; n++)
-        {
-            deps[n].copyYourself();
-            changeLibPathsOnFile(deps[n].getInstallPath());
-        }
+
+	for (DependencyMap::iterator i = deps.begin();
+	     i != deps.end(); ++i) {
+		i->copyYourself();
+	}
     }
-    
-    const int fileToFixAmount = Settings::fileToFixAmount();
-    for(int n=0; n<fileToFixAmount; n++)
-    {
-        changeLibPathsOnFile(Settings::fileToFix(n));
+    for (DependencyMap::iterator i = deps.begin();
+	 i != deps.end(); ++i) {
+	    i->copyYourself();
     }
 }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -39,8 +39,9 @@ std::queue <std::string> openDeps;
 
 void addOpenDeps(const std::string & path)
 {
-	openDeps.push(path);
-	deps.insert(Dependency(path,""));
+	Dependency dep(path,path);
+	openDeps.push(dep.getOriginalPath());
+	deps.insert(dep);
 }
 
 #if 0

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -41,7 +41,7 @@ std::queue <std::string> openDeps;
 void addOpenDeps(const std::string & path)
 {
 	openDeps.push(path);
-	deps.emplace(path,"");
+	deps.insert(Dependency(path,""));
 }
 
 #if 0

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -116,10 +116,13 @@ void collectDependencies(std::string filename)
 	// trim useless info, keep only library name
 	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
 
-	if (!Settings::isPrefixBundled(newlibrary.substr(0,newlibrary.rfind("/")))) continue;
 	std::cout << "`" << filename << "'"
 		  << " -> "
-		  << "`" << newlibrary << "'" << std::endl;
+	if (!Settings::isPrefixBundled(newlibrary.substr(0,newlibrary.rfind("/")))) {
+		std::cout << std::endl;
+		continue;
+	}
+	std::cout << "`" << newlibrary << "'" << std::endl;
 	addDependency(newlibrary,filename);
     }
 }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -111,11 +111,11 @@ void collectSubDependencies()
     while(true)
     {
         dep_amount = deps.size();
-        for(int n=0; n<dep_amount; n++)
+        for(int m=0; m<dep_amount; m++)
         {
             std::cout << "."; fflush(stdout);
             std::vector<std::string> lines;
-            collectDependencies(deps[n].getOriginalPath(), lines);
+            collectDependencies(deps[m].getOriginalPath(), lines);
             
             const int line_amount = lines.size();
             for(int n=0; n<line_amount; n++)
@@ -123,7 +123,7 @@ void collectSubDependencies()
                 if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
                 if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
                 
-		std::cout <<  (deps[n].getOriginalPath())
+		std::cout <<  (deps[m].getOriginalPath())
 			  << " -> "
 			  << lines[n].substr(1, lines[n].rfind(" (") - 1)<< std::endl;
                 addDependency( // trim useless info, keep only library name

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -218,6 +218,7 @@ void createDestDir()
 void doneWithDeps_go()
 {
     std::cout << std::endl;
+    std::cout << "* Collecting dependencies" << std::endl;
     for (DependencyMap::iterator i = deps.begin();
 	 i != deps.end(); ++i) {
         i->print();
@@ -227,6 +228,7 @@ void doneWithDeps_go()
     // copy files if requested by user
     if(Settings::bundleLibs())
     {
+	std::cout << "* Bundling libraries" << std::endl;
         createDestDir();
 
 	for (DependencyMap::iterator i = deps.begin();
@@ -234,6 +236,7 @@ void doneWithDeps_go()
 		i->copyYourself();
 	}
     }
+    std::cout << "* fixing libraries" << std::endl;
     for (DependencyMap::iterator i = deps.begin();
 	 i != deps.end(); ++i) {
 	    i->copyYourself();

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -116,10 +116,10 @@ void collectDependencies(std::string filename)
 	// trim useless info, keep only library name
 	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
 
-	if (!Settings::isPrefixBundled(newlibrary)) continue;
-	std::cout << filename
+	if (!Settings::isPrefixBundled(newlibrary.substr(0,newlibrary.rfind("/")))) continue;
+	std::cout << "`" << filename << "'"
 		  << " -> "
-		  << newlibrary << std::endl;
+		  << "`" << newlibrary << "'" << std::endl;
 	addDependency(newlibrary,filename);
     }
 }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -33,7 +33,6 @@ THE SOFTWARE.
 #include "Dependency.h"
 
 
-typedef std::set<Dependency> DependencyMap;
 DependencyMap deps;
 std::queue <std::string> openDeps;
 
@@ -239,6 +238,6 @@ void doneWithDeps_go()
     std::cout << "* fixing libraries" << std::endl;
     for (DependencyMap::iterator i = deps.begin();
 	 i != deps.end(); ++i) {
-	    i->fixFilesThatDependOnMe();
+	    i->fixFilesThatDependOnMe(deps);
     }
 }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -239,6 +239,6 @@ void doneWithDeps_go()
     std::cout << "* fixing libraries" << std::endl;
     for (DependencyMap::iterator i = deps.begin();
 	 i != deps.end(); ++i) {
-	    i->copyYourself();
+	    i->fixFilesThatDependOnMe();
     }
 }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -117,7 +117,7 @@ void collectDependencies(std::string filename)
 	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
 
 	std::cout << "`" << filename << "'"
-		  << " -> "
+		  << " -> ";
 	if (!Settings::isPrefixBundled(newlibrary.substr(0,newlibrary.rfind("/")))) {
 		std::cout << std::endl;
 		continue;

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -94,6 +94,9 @@ void collectDependencies(std::string filename)
         if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
         if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
         
+	std::cout <<  filename
+		  << " -> "
+		  << lines[n].substr(1, lines[n].rfind(" (") - 1) << std::endl;
         addDependency( // trim useless info, keep only library name
                        lines[n].substr(1, lines[n].rfind(" (") - 1)
                        );
@@ -120,6 +123,9 @@ void collectSubDependencies()
                 if(lines[n][0] != '\t') continue; // only lines beginning with a tab interest us
                 if( lines[n].find(".framework") != std::string::npos ) continue; //Ignore frameworks, we can not handle them
                 
+		std::cout <<  (deps[n].getOriginalPath())
+			  << " -> "
+			  << lines[n].substr(1, lines[n].rfind(" (") - 1)<< std::endl;
                 addDependency( // trim useless info, keep only library name
                                lines[n].substr(1, lines[n].rfind(" (") - 1) 
                                );

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -112,13 +112,11 @@ void collectDependencies(std::string filename)
         std::cout << "."; fflush(stdout);
 	if (newlibrary.empty()) continue; // ignore empty lines
         if (newlibrary[0] != '\t') continue; // only lines beginning with a tab interest us
-        if (newlibrary.find(".framework") != std::string::npos ) continue;
-	// Ignore frameworks, we can not handle them
-        if (newlibrary.find("@rpath") != std::string::npos ) continue;
-	// Ignore @rpath, we can not handle it.
 
 	// trim useless info, keep only library name
 	newlibrary = newlibrary.substr(1, lines[n].rfind(" (") - 1);
+
+	if (!Settings::isPrefixBundled(newlibrary)) continue;
 	std::cout << filename
 		  << " -> "
 		  << newlibrary << std::endl;

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -90,7 +90,7 @@ void collectDependencies(std::string filename, std::vector<std::string>& lines)
 // copying the string is ok here, since the original might not be stable.
 void collectDependencies(std::string filename)
 {
-    DependencyMap::iterator d = deps.find(Dependency(filename,""));
+    DependencyMap::iterator d = deps.find(DependencyKey(filename));
     if (d == deps.end()) {
 	    std::cerr << "Internal error: Dependency " << filename << " is not initialized" << std::endl;
 	    exit(1);

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -118,11 +118,14 @@ void collectDependencies(std::string filename)
 
 	std::cout << "`" << filename << "'"
 		  << " -> ";
-	if (!Settings::isPrefixBundled(newlibrary.substr(0,newlibrary.rfind("/")))) {
-		std::cout << std::endl;
+	std::cout << "`" << newlibrary << "'?";
+	size_t last_slash = newlibrary.rfind("/");
+	if (last_slash != std::string::npos) last_slash++;
+	if (!Settings::isPrefixBundled(newlibrary.substr(0,last_slash))) {
+		std::cout << "No." << std::endl;
 		continue;
 	}
-	std::cout << "`" << newlibrary << "'" << std::endl;
+	std::cout << "Yes." << std::endl;
 	addDependency(newlibrary,filename);
     }
 }

--- a/src/DylibBundler.h
+++ b/src/DylibBundler.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
 void collectDependencies(std::string filename);
 void collectSubDependencies();
+void addOpenDeps(const std::string & path);
 void doneWithDeps_go();
 
 #endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "Settings.h"
 #include <vector>
+#include <iostream>
 
 namespace Settings
 {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -91,6 +91,7 @@ bool isPrefixBundled(std::string prefix)
 {
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;
+    if(prefix.find("@loader_path") != std::string::npos) return false;
     if(prefix.compare("/usr/lib/") == 0) return false;
     if(isPrefixIgnored(prefix)) return false;
     

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -90,7 +90,7 @@ bool isPrefixIgnored(std::string prefix)
 
 bool isPrefixBundled(std::string prefix)
 {
-	std::clog << "checking library prefix `" << prefix << "'." << std::endl;
+    std::clog << "checking library prefix `" << prefix << "'." << std::endl;
     // We don't handle frameworks and @rpath so don't touch them
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -91,7 +91,7 @@ bool isPrefixBundled(std::string prefix)
 {
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;
-    if(prefix.find("@loader_path") != std::string::npos) return false;
+    if(prefix.find("@rpath") != std::string::npos) return false;
     if(prefix.compare("/usr/lib/") == 0) return false;
     if(isPrefixIgnored(prefix)) return false;
     

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -89,6 +89,7 @@ bool isPrefixIgnored(std::string prefix)
 
 bool isPrefixBundled(std::string prefix)
 {
+	std::clog << "checking library prefix `" << prefix << "'." << std::endl;
     // We don't handle frameworks and @rpath so don't touch them
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -89,6 +89,7 @@ bool isPrefixIgnored(std::string prefix)
 
 bool isPrefixBundled(std::string prefix)
 {
+    // We don't handle frameworks and @rpath so don't touch them
     if(prefix.find(".framework") != std::string::npos) return false;
     if(prefix.find("@executable_path") != std::string::npos) return false;
     if(prefix.find("@rpath") != std::string::npos) return false;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -104,7 +104,7 @@ void fixLibDependency(string old_lib_path, string new_lib_name, string target_fi
     }
 }
 
-void copyFile(string from, string to)
+void copyFile(const string & from, const string & to)
 {
     bool override = Settings::canOverwriteFiles();
     if(!override)

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -34,7 +34,7 @@ class Library;
 void tokenize(const std::string& str, const char* delimiters, std::vector<std::string>*);
 bool fileExists( std::string filename );
 
-void copyFile(std::string from, std::string to);
+void copyFile(const std::string & from, const std::string & to);
 
 // executes a command in the native shell and returns output in string
 std::string system_get_output(std::string cmd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main (int argc, char * const argv[])
         {
             Settings::canOverwriteDir(true);
             Settings::canCreateDir(true);
-            continue;    
+            continue;
         }
         else if(strcmp(argv[i],"-cd")==0 or strcmp(argv[i],"--create-dir")==0)
         {
@@ -140,8 +140,8 @@ int main (int argc, char * const argv[])
     std::cout << "* Collecting dependencies"; fflush(stdout);
     
     const int amount = Settings::fileToFixAmount();
-    for(int n=0; n<amount; n++)
-        collectDependencies(Settings::fileToFix(n));
+    for (int n=0; n<amount; n++)
+        addOpenDeps(Settings::fileToFix(n));
     
     collectSubDependencies();
     doneWithDeps_go();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,12 +137,13 @@ int main (int argc, char * const argv[])
         exit(0);
     }
     
-    std::cout << "* Collecting dependencies"; fflush(stdout);
     
+    std::cout << "* Initializing dependencies" << std::endl;
     const int amount = Settings::fileToFixAmount();
     for (int n=0; n<amount; n++)
         addOpenDeps(Settings::fileToFix(n));
     
+    std::cout << "* Collecting dependencies" << std::endl;
     collectSubDependencies();
     doneWithDeps_go();
     

--- a/tests/link_boost_filesystem.cpp
+++ b/tests/link_boost_filesystem.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <boost/filesystem.hpp>
+//og#include <boost/system.hpp>
+using std::cout;
+using namespace boost::filesystem;
+using namespace boost::system;
+
+int main(int argc, char* argv[])
+{
+  if (argc < 2)
+  {
+    cout << "Usage: tut3 path\n";
+    return 1;
+  }
+
+  error_code es;
+  path p = current_path(es);
+
+  try
+  {
+    if (exists(p))
+    {
+      if (is_regular_file(p))
+        cout << p << " size is " << file_size(p) << '\n';
+
+      else if (is_directory(p))
+      {
+        cout << p << " is a directory containing:\n";
+
+        for (directory_entry& x : directory_iterator(p))
+          cout << "    " << x.path() << '\n'; 
+      }
+      else
+        cout << p << " exists, but is not a regular file or directory\n";
+    }
+    else
+      cout << p << " does not exist\n";
+  }
+
+  catch (const filesystem_error& ex)
+  {
+    cout << ex.what() << '\n';
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Hi, with my project I got some strange behaviour of dylibbundler.

Two examples: 
https://travis-ci.org/keinstein/mutabor/builds/359407671
https://travis-ci.org/keinstein/macdylibbundler/builds/365191186
Click on one of the builds to see the log files of the builds.

As I don't own a current Mac I used address sanitizer in order to debug dylibbundler. I couldn't figure out the cause of this strange behaviour. But changing to tree based data structures solved the index problems. Other problems have been solved, too. 

Other changes:
- New elements are added to a queue as well as to the set of dependencies.
- Symbolic links are recorded as a map to the depending object.
- Each new dependency is added to a queue, so that they can be processed one after another
- Dependencies are ordered by filename,path/to/file (a cosmetic decition)
- A test case has been added in order to check my problems
- Automatic builds and checks using Travis CI (you have to activate it yourself after pulling in .travis.yml).
- more verbose output (maybe one should introduce a -v option to show them)
- partial rebuilding
- fail if stdin is not available and the program requests a user supplied path. In that case the user should provide the directory using the library search path

