### PR TITLE
Add rpath support

### DIFF
--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -48,36 +48,36 @@ std::string& rtrim(std::string &s) {
     return s;
 }
 
-//the pathes to search for dylibs, store it globally to parse the environment variables only once
-std::vector<std::string> pathes;
+//the paths to search for dylibs, store it globally to parse the environment variables only once
+std::vector<std::string> paths;
 
-//initialize the dylib search pathes
-void initSearchPathes(){
-    //Check the same pathes the system would search for dylibs
-    std::string searchPathes;
+//initialize the dylib search paths
+void initSearchPaths(){
+    //Check the same paths the system would search for dylibs
+    std::string searchPaths;
     char *dyldLibPath = std::getenv("DYLD_LIBRARY_PATH");
     if( dyldLibPath!=0 )
-        searchPathes = dyldLibPath;
+        searchPaths = dyldLibPath;
     dyldLibPath = std::getenv("DYLD_FALLBACK_FRAMEWORK_PATH");
     if (dyldLibPath != 0)
     {
-        if (!searchPathes.empty() && searchPathes[ searchPathes.size()-1 ] != ':') searchPathes += ":"; 
-        searchPathes += dyldLibPath;
+        if (!searchPaths.empty() && searchPaths[ searchPaths.size()-1 ] != ':') searchPaths += ":";
+        searchPaths += dyldLibPath;
     }
     dyldLibPath = std::getenv("DYLD_FALLBACK_LIBRARY_PATH");
     if (dyldLibPath!=0 )
     {
-        if (!searchPathes.empty() && searchPathes[ searchPathes.size()-1 ] != ':') searchPathes += ":"; 
-        searchPathes += dyldLibPath;
+        if (!searchPaths.empty() && searchPaths[ searchPaths.size()-1 ] != ':') searchPaths += ":";
+        searchPaths += dyldLibPath;
     }
-    if (!searchPathes.empty())
+    if (!searchPaths.empty())
     {
-        std::stringstream ss(searchPathes);
+        std::stringstream ss(searchPaths);
         std::string item;
         while(std::getline(ss, item, ':'))
         {
             if (item[ item.size()-1 ] != '/') item += "/";
-            pathes.push_back(item);
+            paths.push_back(item);
         }
     }
 }
@@ -118,16 +118,16 @@ Dependency::Dependency(std::string path)
     if( !prefix.empty() && prefix[ prefix.size()-1 ] != '/' ) prefix += "/";
     if( prefix.empty() || !fileExists( prefix+filename ) )
     {
-        //the pathes contains at least /usr/lib so if it is empty we have not initilazed it
-        if( pathes.empty() ) initSearchPathes();
+        //the paths contains at least /usr/lib so if it is empty we have not initialized it
+        if( paths.empty() ) initSearchPaths();
         
-        //check if file is contained in one of the pathes
-        for( size_t i=0; i<pathes.size(); ++i)
+        //check if file is contained in one of the paths
+        for( size_t i=0; i<paths.size(); ++i)
         {
-            if (fileExists( pathes[i]+filename ))
+            if (fileExists( paths[i]+filename ))
             {
-                std::cout << "FOUND " << filename << " in " << pathes[i] << std::endl;
-                prefix = pathes[i];
+                std::cout << "FOUND " << filename << " in " << paths[i] << std::endl;
+                prefix = paths[i];
                 missing_prefixes = true; //the prefix was missing
                 break;
             }

--- a/src/DylibBundler.h
+++ b/src/DylibBundler.h
@@ -30,5 +30,7 @@ THE SOFTWARE.
 void collectDependencies(std::string filename);
 void collectSubDependencies();
 void doneWithDeps_go();
+bool isRpath(const std::string& path);
+std::string searchFilenameInRpaths(const std::string& rpath_dep);
 
 #endif

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -177,3 +177,30 @@ int systemp(std::string& cmd)
     std::cout << "    " << cmd.c_str() << std::endl;
     return system(cmd.c_str());
 }
+
+std::string getUserInputDirForFile(const std::string& filename)
+{
+    while (true)
+    {
+        std::cout << "Please specify now the directory where this library can be found (or write 'quit' to abort): ";  fflush(stdout);
+
+        std::string prefix;
+        std::cin >> prefix;
+        std::cout << std::endl;
+
+        if(prefix.compare("quit")==0) exit(1);
+
+        if( !prefix.empty() && prefix[ prefix.size()-1 ] != '/' ) prefix += "/";
+
+        if( !fileExists( prefix+filename ) )
+        {
+            std::cerr << (prefix+filename) << " does not exist. Try again" << std::endl;
+            continue;
+        }
+        else
+        {
+            std::cerr << (prefix+filename) << " was found. /!\\MANUALLY CHECK THE EXECUTABLE WITH 'otool -L', DYLIBBUNDLDER MAY NOT HANDLE CORRECTLY THIS UNSTANDARD/ILL-FORMED DEPENDENCY" << std::endl;
+            return prefix;
+        }
+    }
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -41,5 +41,6 @@ std::string system_get_output(std::string cmd);
 
 // like 'system', runs a command on the system shell, but also prints the command to stdout.
 int systemp(std::string& cmd);
+std::string getUserInputDirForFile(const std::string& filename);
 
 #endif


### PR DESCRIPTION
Current version of dylibbundler does not support rpath references in libraries. Consider the following example:
```
test:
        @rpath/libsdl2pp.dylib (compatibility version 0.0.0, current version 0.0.0)
        /Users/pablo/Repos/test/subprojects/install/lib/libSDL2_ttf-2.0.0.dylib (compatibility version 15.0.0, current version 15.0.0)
        /Users/pablo/Repos/test/subprojects/install/lib/libSDL2-2.0.0.dylib (compatibility version 9.0.0, current version 9.0.0)
        /Users/pablo/Repos/test/subprojects/install/lib/libSDL2_mixer-2.0.0.dylib (compatibility version 3.0.0, current version 3.0.0)
        /Users/pablo/Repos/test/subprojects/install/lib/libSDL2_image-2.0.0.dylib (compatibility version 3.0.0, current version 3.1.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.50.4)
```

Then, running the current version of `dylibbundler`:
```
dylibbundler -od -b -x test -d libs -p @executable_path/libs
* Collecting dependencies...
/!\ WARNING : Library libsdl2pp.dylib  has an incomplete name (location unknown)
Please specify now where this library can be found (or write 'quit' to abort):
```

Even though the `test` binary does include one rpath directory:
```
Load command 19
          cmd LC_RPATH
      cmdsize 72
         path /Users/pablo/Repos/test/release/subprojects/sdl2pp (offset 12)
```

This change aims to add support for such rpath references. It basically collects all rpaths using `otool -l` and looking for `LC_RPATH` in each dependency. Then, whenever there is an `@rpath`, it tries to look for that file in all rpaths collected.

In the previous given example, this the the dependencies for the resulting binary when running `dylibbundler -od -b -x test -d libs -p @executable_path/libs`:
```
test:
        @executable_path/libs/libsdl2pp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @executable_path/libs/libSDL2_ttf-2.0.0.dylib (compatibility version 15.0.0, current version 15.0.0)
        @executable_path/libs/libSDL2-2.0.0.dylib (compatibility version 9.0.0, current version 9.0.0)
        @executable_path/libs/libSDL2_mixer-2.0.0.dylib (compatibility version 3.0.0, current version 3.0.0)
        @executable_path/libs/libSDL2_image-2.0.0.dylib (compatibility version 3.0.0, current version 3.1.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.50.4)
```

I did a little refactoring to avoid code duplication and tried to adapt to the current code style. I'm all ears for any kind of change that may be needed, so feedback is welcome.