### PR TITLE
Fix LC_RPATH for file to fix and its dependencies

### DIFF
--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -223,7 +223,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
     const int symamount = symlinks.size();
     for(int n=0; n<symamount; n++)
     {
-        std::string command = std::string("install_name_tool -change ") +
+        command = std::string("install_name_tool -change ") +
         symlinks[n] + " " + getInnerPath() + " " + file_to_fix;
         
         if( systemp( command ) != 0 )
@@ -238,7 +238,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
     if(missing_prefixes)
     {
         // for main lib file
-        std::string command = std::string("install_name_tool -change ") +
+        command = std::string("install_name_tool -change ") +
         filename + " " + getInnerPath() + " " + file_to_fix;
         
         if( systemp( command ) != 0 )
@@ -251,7 +251,7 @@ void Dependency::fixFileThatDependsOnMe(std::string file_to_fix)
         const int symamount = symlinks.size();
         for(int n=0; n<symamount; n++)
         {
-            std::string command = std::string("install_name_tool -change ") +
+            command = std::string("install_name_tool -change ") +
             symlinks[n] + " " + getInnerPath() + " " + file_to_fix;
             
             if( systemp( command ) != 0 )

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -93,17 +93,6 @@ bool fileExists( std::string filename )
     }
 }
 
-void fixLibDependency(string old_lib_path, string new_lib_name, string target_file_name)
-{
-
-    string command = string("install_name_tool -change ") + old_lib_path + string(" ") + Settings::inside_lib_path() + new_lib_name + string(" ") + target_file_name;
-    if( systemp( command ) != 0 )
-    {
-        cerr << "\n\nError : An error occured while trying to fix depency of " << old_lib_path << " in " << target_file_name << endl;
-        exit(1);
-    }
-}
-
 void copyFile(string from, string to)
 {
     bool override = Settings::canOverwriteFiles();


### PR DESCRIPTION
Previous PR https://github.com/auriamg/macdylibbundler/pull/31 added support for finding libraries that used *rpath* references. However, that's not enough when creating a distributable. We also need to fix the `LC_RPATH` that binaries and shared libraries use. These is the list of changes:

- Remove unused `fixLibDependency` in `Utils`
- Reuse `command` variable to avoid shadowing in `Dependency.cpp`
- Implement `fixRpathsOnFile` to modify the `LC_RPATH` of the file to fix along with its dependencies