### PR TITLE
Fix failing build by adding missing include

### DIFF
--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <set>
 #include <map>
+#include <linux/limits.h>
 #include "Utils.h"
 #include "Settings.h"
 #include "Dependency.h"

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -28,7 +28,9 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <set>
 #include <map>
+#ifdef __linux
 #include <linux/limits.h>
+#endif
 #include "Utils.h"
 #include "Settings.h"
 #include "Dependency.h"


### PR DESCRIPTION
The current version from master fails to build with clang on Ubuntu 18.04. `limits.h` is not being included. This a regression introduced by #31 .

```
clang++ -O2 -c -I./src ./src/Settings.cpp -o ./Settings.o
clang++ -O2 -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
./src/DylibBundler.cpp:112:17: error: use of undeclared identifier 'PATH_MAX'
    char buffer[PATH_MAX];
                ^
1 error generated.
Makefile:8: recipe for target 'dylibbundler' failed
make: *** [dylibbundler] Error 1
```