### PR TITLE
Ensure 'bin' directory exists before instaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean:
 	rm -f ./dylibbundler
 
 install: dylibbundler
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp ./dylibbundler $(DESTDIR)$(PREFIX)/bin/dylibbundler
 	chmod 775 $(DESTDIR)$(PREFIX)/bin/dylibbundler
 


### PR DESCRIPTION
Prevents `cp` error when using custom values of `DESTDIR`/`PREFIX`