### PR TITLE
Quote paths where needed.

### DIFF
--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -199,7 +199,7 @@ void Dependency::copyYourself()
     copyFile(getOriginalPath(), getInstallPath());
     
     // Fix the lib's inner name
-    std::string command = std::string("install_name_tool -id ") + getInnerPath() + " " + getInstallPath();
+    std::string command = std::string("install_name_tool -id \"") + getInnerPath() + "\" \"" + getInstallPath() + "\"";
     if( systemp( command ) != 0 )
     {
         std::cerr << "\n\nError : An error occured while trying to change identity of library " << getInstallPath() << std::endl;

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -156,8 +156,8 @@ void fixRpathsOnFile(const std::string& original_file, const std::string& file_t
 
     for (size_t i=0; i < rpaths_to_fix.size(); ++i)
     {
-        std::string command = std::string("install_name_tool -rpath ") +
-                rpaths_to_fix[i] + " " + Settings::inside_lib_path() + " " + file_to_fix;
+        std::string command = std::string("install_name_tool -rpath \"") +
+                rpaths_to_fix[i] + "\" \"" + Settings::inside_lib_path() + "\" \"" + file_to_fix + "\"";
         if ( systemp(command) != 0)
         {
             std::cerr << "\n\nError : An error occured while trying to fix dependencies of " << file_to_fix << std::endl;
@@ -199,7 +199,7 @@ void addDependency(std::string path, std::string filename)
 void collectDependencies(std::string filename, std::vector<std::string>& lines)
 {
     // execute "otool -l" on the given file and collect the command's output
-    std::string cmd = "otool -l " + filename;
+    std::string cmd = "otool -l \"" + filename + "\"";
     std::string output = system_get_output(cmd);
 
     if(output.find("can't open file")!=std::string::npos or output.find("No such file")!=std::string::npos or output.size()<1)
@@ -314,7 +314,7 @@ void createDestDir()
     if(dest_exists and Settings::canOverwriteDir())
     {
         std::cout << "* Erasing old output directory " << dest_folder.c_str() << std::endl;
-        std::string command = std::string("rm -r ") + dest_folder;
+        std::string command = std::string("rm -r \"") + dest_folder + "\"";
         if( systemp( command ) != 0)
         {
             std::cerr << "\n\nError : An error occured while attempting to overwrite dest folder." << std::endl;
@@ -329,7 +329,7 @@ void createDestDir()
         if(Settings::canCreateDir())
         {
             std::cout << "* Creating output directory " << dest_folder.c_str() << std::endl;
-            std::string command = std::string("mkdir -p ") + dest_folder;
+            std::string command = std::string("mkdir -p \"") + dest_folder + "\"";
             if( systemp( command ) != 0)
             {
                 std::cerr << "\n\nError : An error occured while creating dest folder." << std::endl;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -108,7 +108,7 @@ void copyFile(string from, string to)
     string override_permission = string(override ? "-f " : "-n ");
         
     // copy file to local directory
-    string command = string("cp ") + override_permission + from + string(" ") + to;
+    string command = string("cp ") + override_permission + string("\"") + from + string("\" \"") + to + string("\"");
     if( from != to && systemp( command ) != 0 )
     {
         cerr << "\n\nError : An error occured while trying to copy file " << from << " to " << to << endl;
@@ -116,7 +116,7 @@ void copyFile(string from, string to)
     }
     
     // give it write permission
-    string command2 = string("chmod +w ") + to;
+    string command2 = string("chmod +w \"") + to + "\"";
     if( systemp( command2 ) != 0 )
     {
         cerr << "\n\nError : An error occured while trying to set write permissions on file " << to << endl;
@@ -169,7 +169,7 @@ int systemp(std::string& cmd)
 
 void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name)
 {
-    std::string command = std::string("install_name_tool -change ") + old_name + " " + new_name + " " + binary_file;
+    std::string command = std::string("install_name_tool -change \"") + old_name + "\" \"" + new_name + "\" \"" + binary_file + "\"";
     if( systemp( command ) != 0 )
     {
         std::cerr << "\n\nError: An error occured while trying to fix dependencies of " << binary_file << std::endl;


### PR DESCRIPTION
My app has a space in the name of the appbundle, which caused issues with the system'ed commands. This patch quotes all the paths to handle that.