### PR TITLE
Update project to C++11 compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 DESTDIR=
 PREFIX=/usr/local
-CXXFLAGS = -O2
+CXXFLAGS=-O2 -std=c++11
+
+CPP_FILES=$(wildcard src/*.cpp)
+OBJ_FILES=$(notdir $(CPP_FILES:.cpp=.o))
 
 all: dylibbundler
 
-dylibbundler:
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Settings.cpp -o ./Settings.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/DylibBundler.cpp -o ./DylibBundler.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Dependency.cpp -o ./Dependency.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/main.cpp -o ./main.o
-	$(CXX) $(CXXFLAGS) -c -I./src ./src/Utils.cpp -o ./Utils.o
-	$(CXX) $(CXXFLAGS) -o ./dylibbundler ./Settings.o ./DylibBundler.o ./Dependency.o ./main.o ./Utils.o
+dylibbundler: $(OBJ_FILES)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJ_FILES)
+
+%.o: src/%.cpp
+	$(CXX) -c $(CXXFLAGS) -I./src $< -o $@
 
 clean:
 	rm -f *.o

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -45,7 +45,7 @@ std::string stripPrefix(std::string in)
 }
 
 std::string& rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c){ return !std::isspace(c); }).base(), s.end());
     return s;
 }
 

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <set>
 #include <map>
+#include <sys/param.h>
 #ifdef __linux
 #include <linux/limits.h>
 #endif


### PR DESCRIPTION
1. Adds missing `<sys/param.h>` to DylibBundler.cpp (#57)
2. Incorporates simplified Makefile from #5.

Tested on:
- macOS 11.2.1: Late 2018 Core i7 - Mac Mini
- macOS 11.2.1: 2020 Apple M1 - Mac Mini
- macOS 10.5.7: Late 2012 Core i7 - Mac Mini
- macOS 10.14.6: Mid 2012 Core i7 - MacBook Pro 15"