### PR TITLE
Use LDFLAGS when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJ_FILES=$(notdir $(CPP_FILES:.cpp=.o))
 all: dylibbundler
 
 dylibbundler: $(OBJ_FILES)
-	$(CXX) $(CXXFLAGS) -o $@ $(OBJ_FILES)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJ_FILES)
 
 %.o: src/%.cpp
 	$(CXX) -c $(CXXFLAGS) -I./src $< -o $@


### PR DESCRIPTION
Use LDFLAGS when linking. The Makefile doesn't set any but the user might.