### PR TITLE
Allow user to set CXXFLAGS without losing -std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DESTDIR=
 PREFIX=/usr/local
-CXXFLAGS=-O2 -std=c++11
+CXXFLAGS?=-O2
+CXXFLAGS+=-std=c++11
 
 CPP_FILES=$(wildcard src/*.cpp)
 OBJ_FILES=$(notdir $(CPP_FILES:.cpp=.o))


### PR DESCRIPTION
Allow the user to set the CXXFLAGS environment variable (for example to specify different optimization flags) while not losing flags necessary to build (`-std=c++11`).