### PR TITLE
Allow PREFIX to be set as env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DESTDIR=
-PREFIX=/usr/local
+PREFIX?=/usr/local
 CXXFLAGS?=-O2
 CXXFLAGS+=-std=c++11
 


### PR DESCRIPTION
The Makefile already allowed PREFIX to be set as an argument:

```
make PREFIX=/foo
```

With this change, the user could choose to set it using an environment variable instead:

```
PREFIX=/foo make
```