### PR TITLE
Fix binary signatures, as valid signatures are required on ARM Macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+dylibbundler
+.idea/
+.vscode/
+build/
+cmake-build-*/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.15)
+project(dylibbundler)
+
+set(CMAKE_CXX_STANDARD 11)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+
+add_compile_options(-pipe -Wall -Wextra -Wpedantic)
+
+include_directories(src)
+
+add_executable(dylibbundler
+    src/Dependency.cpp
+    src/Dependency.h
+    src/DylibBundler.cpp
+    src/DylibBundler.h
+    src/main.cpp
+    src/Settings.cpp
+    src/Settings.h
+    src/Utils.cpp
+    src/Utils.h
+)

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -48,9 +48,11 @@ void changeLibPathsOnFile(std::string file_to_fix)
 {
     if (deps_collected.find(file_to_fix) == deps_collected.end())
     {
+        std::cout << "    ";
         collectDependencies(file_to_fix);
+        std::cout << "\n";
     }
-    std::cout << "\n* Fixing dependencies on " << file_to_fix.c_str() << std::endl;
+    std::cout << "  * Fixing dependencies on " << file_to_fix.c_str() << std::endl;
     
     std::vector<Dependency> deps_in_file = deps_per_file[file_to_fix];
     const int dep_amount = deps_in_file.size();
@@ -388,19 +390,23 @@ void doneWithDeps_go()
     {
         createDestDir();
         
-        for(int n=0; n<dep_amount; n++)
+        for(int n=dep_amount-1; n>=0; n--)
         {
+            std::cout << "\n* Processing dependency " << deps[n].getInstallPath() << std::endl;
             deps[n].copyYourself();
             changeLibPathsOnFile(deps[n].getInstallPath());
             fixRpathsOnFile(deps[n].getOriginalPath(), deps[n].getInstallPath());
+            adhocCodeSign(deps[n].getInstallPath());
         }
     }
     
     const int fileToFixAmount = Settings::fileToFixAmount();
-    for(int n=0; n<fileToFixAmount; n++)
+    for(int n=fileToFixAmount-1; n>=0; n--)
     {
+        std::cout << "\n* Processing " << Settings::fileToFix(n) << std::endl;
         copyFile(Settings::fileToFix(n), Settings::fileToFix(n)); // to set write permission
         changeLibPathsOnFile(Settings::fileToFix(n));
         fixRpathsOnFile(Settings::fileToFix(n), Settings::fileToFix(n));
+        adhocCodeSign(Settings::fileToFix(n));
     }
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -44,4 +44,7 @@ int systemp(const std::string& cmd);
 void changeInstallName(const std::string& binary_file, const std::string& old_name, const std::string& new_name);
 std::string getUserInputDirForFile(const std::string& filename);
 
+// sign `file` with an ad-hoc code signature: required for ARM (Apple Silicon) binaries
+void adhocCodeSign(const std::string& file);
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ THE SOFTWARE.
  
  */
 
-const std::string VERSION = "1.0.1";
+const std::string VERSION = "1.0.2";
 
 
 // FIXME - no memory management is done at all (anyway the program closes immediately so who cares?)


### PR DESCRIPTION
I noticed that `dylibbundler` was failing for me on my new M1 Mac, whereas it works fine for the same code on my old Intel Mac.  I found [this Github issue](https://github.com/Homebrew/brew/issues/9082) which shed some light on it, along with the error specifically referring to an invalid signature on one of the libraries in the app bundle, so it seems that adding a step to replace the signatures on the libraries and binary is required for the output of this to run when used on ARM code.

I did test this on my Intel mac as well, and the output still works fine there, too, so this doesn't break those use cases.

As far as why I went with an ad hoc signature, frankly, it was easiest, and anybody who cares about which signing identity is applied to their code can pretty easily go through and update the signatures afterwards.

P.S. If this pull request is accepted, could you please also make another release tag so I can have the Homebrew folks update their copy?