### PR TITLE
Also consider reexported dylibs

### DIFF
--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -261,7 +261,8 @@ void collectDependencies(const std::string& filename, std::vector<std::string>& 
 
     bool searching = false;
     for(const auto& line : raw_lines) {
-        if (line.find("cmd LC_LOAD_DYLIB") != std::string::npos)
+        const auto &is_prefix = [&line](const char *const p) { return line.find(p) != std::string::npos; };
+        if (is_prefix("cmd LC_LOAD_DYLIB") || is_prefix("cmd LC_REEXPORT_DYLIB"))
         {
             if (searching)
             {


### PR DESCRIPTION
At some time in the past, reexported dylibs (marked as `LC_REEXPORT_DYLIB`) started to be ignored. This ofc leads to potentially missing dylibs on other machines. 

It did work back in ce13cb585ead5237813b85e68fe530f085fc0a9e, and I *think* the bug was introduced as part of #50, so I am also mentioning @SCG82.

An example for a library which uses `LC_REEXPORT_DYLIB`: [`darwin.libiconv` in nixpkgs](https://github.com/NixOS/nixpkgs/blob/319850d2a30440a7747cf212dbdcea0e7246e077/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix).

<details>
<summary>
Click to see <code>otool -L</code> of <code>libiconv.dylib</code>
</summary>

```
otool -L $(nix-build -A darwin.libiconv '<nixpkgs>')/lib/libiconv.dylib
```

```
/nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv.dylib:
	/nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv.dylib (compatibility version 7.0.0, current version 7.0.0)
	/nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv-nocharset.dylib (compatibility version 7.0.0, current version 7.0.0, reexport)
	/nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libcharset.1.dylib (compatibility version 2.0.0, current version 2.0.0, reexport)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.60.2)
```
</details>

<details>
<summary>
Click to see <code>otool -l</code> of <code>libiconv.dylib</code>
</summary>

```
otool -l $(nix-build -A darwin.libiconv '<nixpkgs>')/lib/libiconv.dylib
```

```
/nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv.dylib:
Load command 0
      cmd LC_SEGMENT_64
  cmdsize 232
  segname __TEXT
   vmaddr 0x0000000000000000
   vmsize 0x0000000000001000
  fileoff 0
 filesize 4096
  maxprot 0x00000005
 initprot 0x00000005
   nsects 2
    flags 0x0
Section
  sectname __text
   segname __TEXT
      addr 0x0000000000000fb0
      size 0x0000000000000006
    offset 4016
     align 2^4 (16)
    reloff 0
    nreloc 0
     flags 0x80000400
 reserved1 0
 reserved2 0
Section
  sectname __unwind_info
   segname __TEXT
      addr 0x0000000000000fb8
      size 0x0000000000000048
    offset 4024
     align 2^2 (4)
    reloff 0
    nreloc 0
     flags 0x00000000
 reserved1 0
 reserved2 0
Load command 1
      cmd LC_SEGMENT_64
  cmdsize 72
  segname __LINKEDIT
   vmaddr 0x0000000000001000
   vmsize 0x0000000000000068
  fileoff 4096
 filesize 104
  maxprot 0x00000001
 initprot 0x00000001
   nsects 0
    flags 0x0
Load command 2
          cmd LC_ID_DYLIB
      cmdsize 104
         name /nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv.dylib (offset 24)
   time stamp 1 Wed Dec 31 16:00:01 1969
      current version 7.0.0
compatibility version 7.0.0
Load command 3
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 0
    rebase_size 0
       bind_off 0
      bind_size 0
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 4096
    export_size 24
Load command 4
     cmd LC_SYMTAB
 cmdsize 24
  symoff 4128
   nsyms 2
  stroff 4160
 strsize 40
Load command 5
            cmd LC_DYSYMTAB
        cmdsize 80
      ilocalsym 0
      nlocalsym 0
     iextdefsym 0
     nextdefsym 1
      iundefsym 1
      nundefsym 1
         tocoff 0
           ntoc 0
      modtaboff 0
        nmodtab 0
   extrefsymoff 0
    nextrefsyms 0
 indirectsymoff 0
  nindirectsyms 0
      extreloff 0
        nextrel 0
      locreloff 0
        nlocrel 0
Load command 6
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.12
      sdk 10.12
Load command 7
      cmd LC_SOURCE_VERSION
  cmdsize 16
  version 0.0
Load command 8
          cmd LC_REEXPORT_DYLIB
      cmdsize 112
         name /nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libiconv-nocharset.dylib (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 7.0.0
compatibility version 7.0.0
Load command 9
          cmd LC_REEXPORT_DYLIB
      cmdsize 104
         name /nix/store/qz8nr870hpdn6bdljjw8zzvd3sjjr941-libiconv-50/lib/libcharset.1.dylib (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 2.0.0
compatibility version 2.0.0
Load command 10
          cmd LC_LOAD_DYLIB
      cmdsize 56
         name /usr/lib/libSystem.B.dylib (offset 24)
   time stamp 2 Wed Dec 31 16:00:02 1969
      current version 1238.60.2
compatibility version 1.0.0
Load command 11
      cmd LC_FUNCTION_STARTS
  cmdsize 16
  dataoff 4120
 datasize 8
Load command 12
      cmd LC_DATA_IN_CODE
  cmdsize 16
  dataoff 4128
 datasize 0
```
</details>

---

Thanks for this great tool, it is extremely useful!