### PR TITLE
feat: add '--install-deps-path' and '--skip-*' options

### DIFF
--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -169,7 +169,7 @@ std::string Dependency::getInstallPath()
 }
 std::string Dependency::getInnerPath()
 {
-    return Settings::inside_lib_path() + new_name;
+    return Settings::inside_lib_load_path() + new_name;
 }
 
 
@@ -194,10 +194,14 @@ bool Dependency::mergeIfSameAs(Dependency& dep2)
     return false;
 }
 
-void Dependency::copyYourself()
+bool Dependency::copyYourself()
 {
-    copyFile(getOriginalPath(), getInstallPath());
+    const bool should_patch = copyFile(getOriginalPath(), getInstallPath());
     
+    if (!should_patch) {
+        return false;
+    }
+
     // Fix the lib's inner name
     std::string command = std::string("install_name_tool -id \"") + getInnerPath() + "\" \"" + getInstallPath() + "\"";
     if( systemp( command ) != 0 )
@@ -205,6 +209,8 @@ void Dependency::copyYourself()
         std::cerr << "\n\nError : An error occured while trying to change identity of library " << getInstallPath() << std::endl;
         exit(1);
     }
+
+    return true;
 }
 
 void Dependency::fixFileThatDependsOnMe(const std::string& file_to_fix)

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -169,7 +169,7 @@ std::string Dependency::getInstallPath()
 }
 std::string Dependency::getInnerPath()
 {
-    return Settings::inside_lib_load_path() + new_name;
+    return Settings::inside_dep_load_path() + new_name;
 }
 
 

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -167,9 +167,9 @@ std::string Dependency::getInstallPath()
 {
     return Settings::destFolder() + new_name;
 }
-std::string Dependency::getInnerPath()
+std::string Dependency::getInnerPath(const std::string& new_rpath)
 {
-    return Settings::inside_dep_load_path() + new_name;
+    return new_rpath + new_name;
 }
 
 
@@ -203,7 +203,7 @@ bool Dependency::copyYourself()
     }
 
     // Fix the lib's inner name
-    std::string command = std::string("install_name_tool -id \"") + getInnerPath() + "\" \"" + getInstallPath() + "\"";
+    std::string command = std::string("install_name_tool -id \"") + getInnerPath(Settings::inside_dep_load_path()) + "\" \"" + getInstallPath() + "\"";
     if( systemp( command ) != 0 )
     {
         std::cerr << "\n\nError : An error occured while trying to change identity of library " << getInstallPath() << std::endl;
@@ -213,27 +213,27 @@ bool Dependency::copyYourself()
     return true;
 }
 
-void Dependency::fixFileThatDependsOnMe(const std::string& file_to_fix)
+void Dependency::fixFileThatDependsOnMe(const std::string& file_to_fix, const std::string& new_rpath)
 {
     // for main lib file
-    changeInstallName(file_to_fix, getOriginalPath(), getInnerPath());
+    changeInstallName(file_to_fix, getOriginalPath(), getInnerPath(new_rpath));
     // for symlinks
     const int symamount = symlinks.size();
     for(int n=0; n<symamount; n++)
     {
-        changeInstallName(file_to_fix, symlinks[n], getInnerPath());
+        changeInstallName(file_to_fix, symlinks[n], getInnerPath(new_rpath));
     }
     
     // FIXME - hackish
     if(missing_prefixes)
     {
         // for main lib file
-        changeInstallName(file_to_fix, filename, getInnerPath());
+        changeInstallName(file_to_fix, filename, getInnerPath(new_rpath));
         // for symlinks
         const int symamount = symlinks.size();
         for(int n=0; n<symamount; n++)
         {
-            changeInstallName(file_to_fix, symlinks[n], getInnerPath());
+            changeInstallName(file_to_fix, symlinks[n], getInnerPath(new_rpath));
         }
     }
 }

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -141,7 +141,7 @@ Dependency::Dependency(std::string path, const std::string& dependent_file)
     }
     
     //If the location is still unknown, ask the user for search path
-    if( !Settings::isPrefixIgnored(prefix)
+    if( !Settings::isPrefixIgnored(prefix) && !Settings::skipMissing()
         && ( prefix.empty() || !fileExists( prefix+filename ) ) )
     {
         std::cerr << "\n/!\\ WARNING : Library " << filename << " has an incomplete name (location unknown)" << std::endl;

--- a/src/Dependency.cpp
+++ b/src/Dependency.cpp
@@ -196,10 +196,10 @@ bool Dependency::mergeIfSameAs(Dependency& dep2)
 
 bool Dependency::copyYourself()
 {
-    const bool should_patch = copyFile(getOriginalPath(), getInstallPath());
+    const bool was_copied = copyFile(getOriginalPath(), getInstallPath());
     
-    if (!should_patch) {
-        return false;
+    if (!was_copied || Settings::skipPatching()) {
+        return was_copied;
     }
 
     // Fix the lib's inner name

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -54,9 +54,9 @@ public:
     std::string getSymlink(const int i) const{ return symlinks[i]; }
     std::string getPrefix() const{ return prefix; }
 
-    void copyYourself();
+    bool copyYourself();
     void fixFileThatDependsOnMe(const std::string& file);
-    
+
     // Compares the given dependency with this one. If both refer to the same file,
     // it returns true and merges both entries into one.
     bool mergeIfSameAs(Dependency& dep2);

--- a/src/Dependency.h
+++ b/src/Dependency.h
@@ -46,7 +46,7 @@ public:
     std::string getOriginalFileName() const{ return filename; }
     std::string getOriginalPath() const{ return prefix+filename; }
     std::string getInstallPath();
-    std::string getInnerPath();
+    std::string getInnerPath(const std::string& new_rpath);
         
     void addSymlink(const std::string& s);
     int getSymlinkAmount() const{ return symlinks.size(); }
@@ -55,7 +55,7 @@ public:
     std::string getPrefix() const{ return prefix; }
 
     bool copyYourself();
-    void fixFileThatDependsOnMe(const std::string& file);
+    void fixFileThatDependsOnMe(const std::string& file, const std::string& new_rpath);
 
     // Compares the given dependency with this one. If both refer to the same file,
     // it returns true and merges both entries into one.

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -44,7 +44,7 @@ std::map<std::string, bool> deps_collected;
 std::map<std::string, std::vector<std::string> > rpaths_per_file;
 std::map<std::string, std::string> rpath_to_fullpath;
 
-void changeLibPathsOnFile(std::string file_to_fix)
+void changeLibPathsOnFile(std::string file_to_fix, const std::string& new_rpath)
 {
     if (deps_collected.find(file_to_fix) == deps_collected.end())
     {
@@ -58,7 +58,7 @@ void changeLibPathsOnFile(std::string file_to_fix)
     const int dep_amount = deps_in_file.size();
     for(int n=0; n<dep_amount; n++)
     {
-        deps_in_file[n].fixFileThatDependsOnMe(file_to_fix);
+        deps_in_file[n].fixFileThatDependsOnMe(file_to_fix, new_rpath);
     }
 }
 
@@ -398,7 +398,7 @@ void doneWithDeps_go()
             if (!should_patch) {
                 continue;
             }
-            changeLibPathsOnFile(deps[n].getInstallPath());
+            changeLibPathsOnFile(deps[n].getInstallPath(), Settings::inside_dep_load_path());
             fixRpathsOnFile(deps[n].getOriginalPath(), deps[n].getInstallPath(), Settings::inside_dep_load_path());
             adhocCodeSign(deps[n].getInstallPath());
         }
@@ -409,7 +409,7 @@ void doneWithDeps_go()
     {
         std::cout << "\n* Processing " << Settings::fileToFix(n) << std::endl;
         copyFile(Settings::fileToFix(n), Settings::fileToFix(n)); // to set write permission
-        changeLibPathsOnFile(Settings::fileToFix(n));
+        changeLibPathsOnFile(Settings::fileToFix(n), Settings::inside_bin_load_path());
         fixRpathsOnFile(Settings::fileToFix(n), Settings::fileToFix(n), Settings::inside_bin_load_path());
         adhocCodeSign(Settings::fileToFix(n));
     }

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -398,10 +398,15 @@ void doneWithDeps_go()
         for(int n=dep_amount-1; n>=0; n--)
         {
             std::cout << "\n* Processing dependency " << deps[n].getInstallPath() << std::endl;
-            const bool should_patch = deps[n].copyYourself();
-            if (!should_patch || Settings::skipPatching()) {
+            const bool was_copied = deps[n].copyYourself();
+            if (!was_copied) {
                 continue;
             }
+
+            if (Settings::skipPatching()) {
+                continue;
+            }
+
             changeLibPathsOnFile(deps[n].getInstallPath(), Settings::inside_dep_load_path());
             fixRpathsOnFile(deps[n].getOriginalPath(), deps[n].getInstallPath(), Settings::inside_dep_load_path());
             adhocCodeSign(deps[n].getInstallPath());
@@ -417,6 +422,7 @@ void doneWithDeps_go()
         if (Settings::skipPatching()) {
             continue;
         }
+
         changeLibPathsOnFile(Settings::fileToFix(n), Settings::inside_bin_load_path());
         fixRpathsOnFile(Settings::fileToFix(n), Settings::fileToFix(n), Settings::inside_bin_load_path());
         adhocCodeSign(Settings::fileToFix(n));

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -252,7 +252,7 @@ void collectDependencies(const std::string& filename, std::vector<std::string>& 
     if(output.find("can't open file")!=std::string::npos or output.find("No such file")!=std::string::npos or output.size()<1)
     {
         std::cerr << "Cannot find file " << filename << " to read its dependencies" << std::endl;
-        if (Settings::ignoreMissing()) {
+        if (Settings::skipMissing()) {
             return;
         }
 

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -252,6 +252,10 @@ void collectDependencies(const std::string& filename, std::vector<std::string>& 
     if(output.find("can't open file")!=std::string::npos or output.find("No such file")!=std::string::npos or output.size()<1)
     {
         std::cerr << "Cannot find file " << filename << " to read its dependencies" << std::endl;
+        if (Settings::ignoreMissing()) {
+            return;
+        }
+
         exit(1);
     }
     
@@ -395,7 +399,7 @@ void doneWithDeps_go()
         {
             std::cout << "\n* Processing dependency " << deps[n].getInstallPath() << std::endl;
             const bool should_patch = deps[n].copyYourself();
-            if (!should_patch) {
+            if (!should_patch || Settings::skipPatching()) {
                 continue;
             }
             changeLibPathsOnFile(deps[n].getInstallPath(), Settings::inside_dep_load_path());
@@ -409,6 +413,10 @@ void doneWithDeps_go()
     {
         std::cout << "\n* Processing " << Settings::fileToFix(n) << std::endl;
         copyFile(Settings::fileToFix(n), Settings::fileToFix(n)); // to set write permission
+
+        if (Settings::skipPatching()) {
+            continue;
+        }
         changeLibPathsOnFile(Settings::fileToFix(n), Settings::inside_bin_load_path());
         fixRpathsOnFile(Settings::fileToFix(n), Settings::fileToFix(n), Settings::inside_bin_load_path());
         adhocCodeSign(Settings::fileToFix(n));

--- a/src/DylibBundler.cpp
+++ b/src/DylibBundler.cpp
@@ -399,7 +399,7 @@ void doneWithDeps_go()
                 continue;
             }
             changeLibPathsOnFile(deps[n].getInstallPath());
-            fixRpathsOnFile(deps[n].getOriginalPath(), deps[n].getInstallPath(), Settings::inside_lib_load_path());
+            fixRpathsOnFile(deps[n].getOriginalPath(), deps[n].getInstallPath(), Settings::inside_dep_load_path());
             adhocCodeSign(deps[n].getInstallPath());
         }
     }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -29,15 +29,18 @@ namespace Settings
 {
 
 bool overwrite_files = false;
+bool ignore_existing = true;
 bool overwrite_dir = false;
 bool create_dir = false;
 bool codesign = true;
 
+bool canIgnoreExisting(){ return ignore_existing; }
 bool canOverwriteFiles(){ return overwrite_files; }
 bool canOverwriteDir(){ return overwrite_dir; }
 bool canCreateDir(){ return create_dir; }
 bool canCodesign(){ return codesign; }
 
+void canIgnoreExisting(bool permission){ ignore_existing = permission; }
 void canOverwriteFiles(bool permission){ overwrite_files = permission; }
 void canOverwriteDir(bool permission){ overwrite_dir = permission; }
 void canCreateDir(bool permission){ create_dir = permission; }
@@ -63,13 +66,22 @@ void addFileToFix(const std::string& path){ files.push_back(path); }
 int fileToFixAmount(){ return files.size(); }
 std::string fileToFix(const int n){ return files[n]; }
 
-std::string inside_path_str = "@executable_path/../libs/";
-std::string inside_lib_path(){ return inside_path_str; }
-void inside_lib_path(const std::string& p)
+std::string inside_bin_load_path_str = "@executable_path/../libs/";
+std::string inside_bin_load_path(){ return inside_bin_load_path_str; }
+void inside_bin_load_path(const std::string& p)
 {
-    inside_path_str = p;
+    inside_bin_load_path_str = p;
     // fix path if needed so it ends with '/'
-    if( inside_path_str[ inside_path_str.size()-1 ] != '/' ) inside_path_str += "/";
+    if( inside_bin_load_path_str[ inside_bin_load_path_str.size()-1 ] != '/' ) inside_bin_load_path_str += "/";
+}
+
+std::string inside_lib_load_path_str = "";
+std::string inside_lib_load_path(){ return inside_lib_load_path_str; }
+void inside_lib_load_path(const std::string& p)
+{
+    inside_lib_load_path_str = p;
+    // fix path if needed so it ends with '/'
+    if( inside_lib_load_path_str[ inside_lib_load_path_str.size()-1 ] != '/' ) inside_lib_load_path_str += "/";
 }
 
 std::vector<std::string> prefixes_to_ignore;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -29,7 +29,7 @@ namespace Settings
 {
 
 bool overwrite_files = false;
-bool skip_existing = true;
+bool skip_existing = false;
 bool overwrite_dir = false;
 bool create_dir = false;
 bool codesign = true;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -51,6 +51,13 @@ bool bundleLibs_bool = false;
 bool bundleLibs(){ return bundleLibs_bool; }
 void bundleLibs(bool on){ bundleLibs_bool = on; }
 
+bool skipPatching_bool = false;
+bool skipPatching(){ return skipPatching_bool && bundleLibs_bool; }
+void skipPatching(bool on){ skipPatching_bool = on; }
+
+bool ignoreMissing_bool = false;
+bool ignoreMissing(){ return ignoreMissing_bool; }
+void ignoreMissing(bool on){ ignoreMissing_bool = on; }
 
 std::string dest_folder_str = "./libs/";
 std::string destFolder(){ return dest_folder_str; }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -75,13 +75,13 @@ void inside_bin_load_path(const std::string& p)
     if( inside_bin_load_path_str[ inside_bin_load_path_str.size()-1 ] != '/' ) inside_bin_load_path_str += "/";
 }
 
-std::string inside_lib_load_path_str = "";
-std::string inside_lib_load_path(){ return inside_lib_load_path_str; }
-void inside_lib_load_path(const std::string& p)
+std::string inside_dep_load_path_str = "";
+std::string inside_dep_load_path(){ return inside_dep_load_path_str; }
+void inside_dep_load_path(const std::string& p)
 {
-    inside_lib_load_path_str = p;
+    inside_dep_load_path_str = p;
     // fix path if needed so it ends with '/'
-    if( inside_lib_load_path_str[ inside_lib_load_path_str.size()-1 ] != '/' ) inside_lib_load_path_str += "/";
+    if( inside_dep_load_path_str[ inside_dep_load_path_str.size()-1 ] != '/' ) inside_dep_load_path_str += "/";
 }
 
 std::vector<std::string> prefixes_to_ignore;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -29,18 +29,18 @@ namespace Settings
 {
 
 bool overwrite_files = false;
-bool ignore_existing = true;
+bool skip_existing = true;
 bool overwrite_dir = false;
 bool create_dir = false;
 bool codesign = true;
 
-bool canIgnoreExisting(){ return ignore_existing; }
+bool skipExisting(){ return skip_existing; }
 bool canOverwriteFiles(){ return overwrite_files; }
 bool canOverwriteDir(){ return overwrite_dir; }
 bool canCreateDir(){ return create_dir; }
 bool canCodesign(){ return codesign; }
 
-void canIgnoreExisting(bool permission){ ignore_existing = permission; }
+void skipExisting(bool permission){ skip_existing = permission; }
 void canOverwriteFiles(bool permission){ overwrite_files = permission; }
 void canOverwriteDir(bool permission){ overwrite_dir = permission; }
 void canCreateDir(bool permission){ create_dir = permission; }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -55,9 +55,9 @@ bool skipPatching_bool = false;
 bool skipPatching(){ return skipPatching_bool && bundleLibs_bool; }
 void skipPatching(bool on){ skipPatching_bool = on; }
 
-bool ignoreMissing_bool = false;
-bool ignoreMissing(){ return ignoreMissing_bool; }
-void ignoreMissing(bool on){ ignoreMissing_bool = on; }
+bool skipMissing_bool = false;
+bool skipMissing(){ return skipMissing_bool; }
+void skipMissing(bool on){ skipMissing_bool = on; }
 
 std::string dest_folder_str = "./libs/";
 std::string destFolder(){ return dest_folder_str; }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -63,8 +63,8 @@ std::string fileToFix(const int n);
 std::string inside_bin_load_path();
 void inside_bin_load_path(const std::string& p);
 
-std::string inside_lib_load_path();
-void inside_lib_load_path(const std::string& p);
+std::string inside_dep_load_path();
+void inside_dep_load_path(const std::string& p);
 
 void addSearchPath(const std::string& path);
 int searchPathAmount();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -56,8 +56,8 @@ void bundleLibs(bool on);
 bool skipPatching();
 void skipPatching(bool on);
 
-bool ignoreMissing();
-void ignoreMissing(bool on);
+bool skipMissing();
+void skipMissing(bool on);
 
 std::string destFolder();
 void destFolder(const std::string& path);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -38,8 +38,8 @@ void ignore_prefix(std::string prefix);
 bool canOverwriteFiles();
 void canOverwriteFiles(bool permission);
 
-bool canIgnoreExisting();
-void canIgnoreExisting(bool permission);
+bool skipExisting();
+void skipExisting(bool permission);
 
 bool canOverwriteDir();
 void canOverwriteDir(bool permission);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -53,6 +53,12 @@ void canCodesign(bool permission);
 bool bundleLibs();
 void bundleLibs(bool on);
 
+bool skipPatching();
+void skipPatching(bool on);
+
+bool ignoreMissing();
+void ignoreMissing(bool on);
+
 std::string destFolder();
 void destFolder(const std::string& path);
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -38,6 +38,9 @@ void ignore_prefix(std::string prefix);
 bool canOverwriteFiles();
 void canOverwriteFiles(bool permission);
 
+bool canIgnoreExisting();
+void canIgnoreExisting(bool permission);
+
 bool canOverwriteDir();
 void canOverwriteDir(bool permission);
 
@@ -57,8 +60,11 @@ void addFileToFix(const std::string& path);
 int fileToFixAmount();
 std::string fileToFix(const int n);
 
-std::string inside_lib_path();
-void inside_lib_path(const std::string& p);
+std::string inside_bin_load_path();
+void inside_bin_load_path(const std::string& p);
+
+std::string inside_lib_load_path();
+void inside_lib_load_path(const std::string& p);
 
 void addSearchPath(const std::string& path);
 int searchPathAmount();

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -96,7 +96,7 @@ bool fileExists(const std::string& filename)
 bool copyFile(const string& from, const string& to)
 {
     bool override = Settings::canOverwriteFiles();
-    bool ignore = Settings::canIgnoreExisting();
+    bool ignore = Settings::skipExisting();
     if( from != to && !override )
     {
         if(fileExists( to ))

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -93,13 +93,20 @@ bool fileExists(const std::string& filename)
     }
 }
 
-void copyFile(const string& from, const string& to)
+bool copyFile(const string& from, const string& to)
 {
     bool override = Settings::canOverwriteFiles();
+    bool ignore = Settings::canIgnoreExisting();
     if( from != to && !override )
     {
         if(fileExists( to ))
         {
+            if (ignore)
+            {
+                cerr << "\n/!\\ WARNING : library " << to.c_str() << " already exists in dest dir and will not be patched." << endl;
+                return false;
+            }
+
             cerr << "\n\nError : File " << to.c_str() << " already exists. Remove it or enable overwriting." << endl;
             exit(1);
         }
@@ -122,6 +129,8 @@ void copyFile(const string& from, const string& to)
         cerr << "\n\nError : An error occured while trying to set write permissions on file " << to << endl;
         exit(1);
     }
+
+    return true;
 }
 
 std::string system_get_output(const std::string& cmd)

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -34,7 +34,7 @@ class Library;
 void tokenize(const std::string& str, const char* delimiters, std::vector<std::string>*);
 bool fileExists(const std::string& filename);
 
-void copyFile(const std::string& from, const std::string& to);
+bool copyFile(const std::string& from, const std::string& to);
 
 // executes a command in the native shell and returns output in string
 std::string system_get_output(const std::string& cmd);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main (int argc, char * const argv[])
         }
         else if(strcmp(argv[i],"-sm")==0 or strcmp(argv[i],"--skip-missing")==0)
         {
-            Settings::ignoreMissing(true);
+            Settings::skipMissing(true);
             continue;
         }
         else if(strcmp(argv[i],"-p")==0 or strcmp(argv[i],"--install-path")==0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,12 +58,12 @@ void showHelp()
     std::cout << " -b, --bundle-deps" << std::endl;
     std::cout << "-sp, --skip-patching (do not change load paths in binaries, just collect all dependencies. Has effect only when --bundle-deps is set)" << std::endl;
     std::cout << "-sm, --skip-missing (just skip missing dependencies and collect what is possible)" << std::endl;
+    std::cout << "-se, --skip-existing (makes bundler to leave existing files in output directory intact)" << std::endl;
     std::cout << " -d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
     std::cout << " -p, --install-path <'inner' path of bundled libraries when patching files from --fix-file (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
     std::cout << "-dp, --install-deps-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
     std::cout << " -s, --search-path <directory to add to list of locations searched>" << std::endl;
     std::cout << "-of, --overwrite-files (allow overwriting files in output directory)" << std::endl;
-    std::cout << "-ie, --ignore-existing (makes bundler to leave existing files in output directory intact)" << std::endl;
     std::cout << "-od, --overwrite-dir (totally overwrite output directory if it already exists. implies --create-dir)" << std::endl;
     std::cout << "-cd, --create-dir (creates output directory if necessary)" << std::endl;
     std::cout << "-ns, --no-codesign (disables ad-hoc codesigning)" << std::endl;
@@ -97,6 +97,11 @@ int main (int argc, char * const argv[])
             Settings::skipMissing(true);
             continue;
         }
+        else if(strcmp(argv[i],"-se")==0 or strcmp(argv[i],"--skip-existing")==0)
+        {
+            Settings::skipExisting(true);
+            continue;
+        }
         else if(strcmp(argv[i],"-p")==0 or strcmp(argv[i],"--install-path")==0)
         {
             i++;
@@ -119,11 +124,6 @@ int main (int argc, char * const argv[])
         {
             i++;
             Settings::destFolder(argv[i]);
-            continue;
-        }
-        else if(strcmp(argv[i],"-ie")==0 or strcmp(argv[i],"--ignore-existing")==0)
-        {
-            Settings::canIgnoreExisting(true);
             continue;
         }
         else if(strcmp(argv[i],"-of")==0 or strcmp(argv[i],"--overwrite-files")==0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,11 +53,11 @@ void showHelp()
 {
     std::cout << "dylibbundler " << VERSION << std::endl;
     std::cout << "dylibbundler is a utility that helps bundle dynamic libraries inside macOS app bundles.\n" << std::endl;
-    
+
     std::cout << " -x, --fix-file <file to fix (executable or app plug-in)>" << std::endl;
     std::cout << " -b, --bundle-deps" << std::endl;
     std::cout << "-sp, --skip-patching (do not change load paths in binaries, just collect all dependencies. Has effect only when --bundle-deps is set)" << std::endl;
-    std::cout << "-im, --ignore-missing (just skip missing dependencies and collect what is possible)" << std::endl;
+    std::cout << "-sm, --skip-missing (just skip missing dependencies and collect what is possible)" << std::endl;
     std::cout << " -d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
     std::cout << " -p, --install-path <'inner' path of bundled libraries when patching files from --fix-file (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
     std::cout << "-dp, --install-deps-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
@@ -92,7 +92,7 @@ int main (int argc, char * const argv[])
             Settings::skipPatching(true);
             continue;
         }
-        else if(strcmp(argv[i],"-im")==0 or strcmp(argv[i],"--ignore-missing")==0)
+        else if(strcmp(argv[i],"-sm")==0 or strcmp(argv[i],"--skip-missing")==0)
         {
             Settings::ignoreMissing(true);
             continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,8 @@ void showHelp()
     
     std::cout << " -x, --fix-file <file to fix (executable or app plug-in)>" << std::endl;
     std::cout << " -b, --bundle-deps" << std::endl;
+    std::cout << "-sp, --skip-patching (do not change load paths in binaries, just collect all dependencies. Has effect only when --bundle-deps is set)" << std::endl;
+    std::cout << "-im, --ignore-missing (just skip missing dependencies and collect what is possible)" << std::endl;
     std::cout << " -d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
     std::cout << " -p, --install-path <'inner' path of bundled libraries when patching files from --fix-file (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
     std::cout << "-dp, --install-deps-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
@@ -84,6 +86,16 @@ int main (int argc, char * const argv[])
         {
             Settings::bundleLibs(true);
             continue;    
+        }
+        else if(strcmp(argv[i],"-sp")==0 or strcmp(argv[i],"--skip-patching")==0)
+        {
+            Settings::skipPatching(true);
+            continue;
+        }
+        else if(strcmp(argv[i],"-im")==0 or strcmp(argv[i],"--ignore-missing")==0)
+        {
+            Settings::ignoreMissing(true);
+            continue;
         }
         else if(strcmp(argv[i],"-p")==0 or strcmp(argv[i],"--install-path")==0)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,17 +54,19 @@ void showHelp()
     std::cout << "dylibbundler " << VERSION << std::endl;
     std::cout << "dylibbundler is a utility that helps bundle dynamic libraries inside macOS app bundles.\n" << std::endl;
     
-    std::cout << "-x, --fix-file <file to fix (executable or app plug-in)>" << std::endl;
-    std::cout << "-b, --bundle-deps" << std::endl;
-    std::cout << "-d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
-    std::cout << "-p, --install-path <'inner' path of bundled libraries (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
-    std::cout << "-s, --search-path <directory to add to list of locations searched>" << std::endl;
+    std::cout << " -x, --fix-file <file to fix (executable or app plug-in)>" << std::endl;
+    std::cout << " -b, --bundle-deps" << std::endl;
+    std::cout << " -d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
+    std::cout << " -p, --install-path <'inner' path of bundled libraries when patching files from --fix-file (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
+    std::cout << "-lp, --install-libs-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
+    std::cout << " -s, --search-path <directory to add to list of locations searched>" << std::endl;
     std::cout << "-of, --overwrite-files (allow overwriting files in output directory)" << std::endl;
+    std::cout << "-ie, --ignore-existing (makes bundler to leave existing files in output directory intact)" << std::endl;
     std::cout << "-od, --overwrite-dir (totally overwrite output directory if it already exists. implies --create-dir)" << std::endl;
     std::cout << "-cd, --create-dir (creates output directory if necessary)" << std::endl;
     std::cout << "-ns, --no-codesign (disables ad-hoc codesigning)" << std::endl;
-    std::cout << "-i, --ignore <location to ignore> (will ignore libraries in this directory)" << std::endl;
-    std::cout << "-h, --help" << std::endl;
+    std::cout << " -i, --ignore <location to ignore> (will ignore libraries in this directory)" << std::endl;
+    std::cout << " -h, --help" << std::endl;
 }
 
 int main (int argc, char * const argv[])
@@ -87,7 +89,13 @@ int main (int argc, char * const argv[])
         else if(strcmp(argv[i],"-p")==0 or strcmp(argv[i],"--install-path")==0)
         {
             i++;
-            Settings::inside_lib_path(argv[i]);
+            Settings::inside_bin_load_path(argv[i]);
+            continue;
+        }
+        else if(strcmp(argv[i],"-lp")==0 or strcmp(argv[i],"--install-libs-path")==0)
+        {
+            i++;
+            Settings::inside_lib_load_path(argv[i]);
             continue;
         }
         else if(strcmp(argv[i],"-i")==0 or strcmp(argv[i],"--ignore")==0)
@@ -100,6 +108,11 @@ int main (int argc, char * const argv[])
         {
             i++;
             Settings::destFolder(argv[i]);
+            continue;
+        }
+        else if(strcmp(argv[i],"-ie")==0 or strcmp(argv[i],"--ignore-existing")==0)
+        {
+            Settings::canIgnoreExisting(true);
             continue;
         }
         else if(strcmp(argv[i],"-of")==0 or strcmp(argv[i],"--overwrite-files")==0)
@@ -142,6 +155,11 @@ int main (int argc, char * const argv[])
             showHelp();
             exit(1);
         }
+    }
+
+    if (Settings::inside_lib_load_path() == "") {
+        // Default 'libs' load path to be equal to 'bin' load path for backward compatibility with older dylibbundler versions logic
+        Settings::inside_lib_load_path(Settings::inside_bin_load_path());
     }
     
     if(not Settings::bundleLibs() and Settings::fileToFixAmount()<1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ void showHelp()
     std::cout << " -b, --bundle-deps" << std::endl;
     std::cout << " -d, --dest-dir <directory to send bundled libraries (relative to cwd)>" << std::endl;
     std::cout << " -p, --install-path <'inner' path of bundled libraries when patching files from --fix-file (usually relative to executable, by default '@executable_path/../libs/')>" << std::endl;
-    std::cout << "-lp, --install-libs-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
+    std::cout << "-dp, --install-deps-path <'inner' path of bundled libraries to set when patching dependencies ('@loader_path/' can be an option, defaults to '--install-path' value)>" << std::endl;
     std::cout << " -s, --search-path <directory to add to list of locations searched>" << std::endl;
     std::cout << "-of, --overwrite-files (allow overwriting files in output directory)" << std::endl;
     std::cout << "-ie, --ignore-existing (makes bundler to leave existing files in output directory intact)" << std::endl;
@@ -71,7 +71,6 @@ void showHelp()
 
 int main (int argc, char * const argv[])
 {
-    
     // parse arguments    
     for(int i=0; i<argc; i++)
     {
@@ -92,10 +91,10 @@ int main (int argc, char * const argv[])
             Settings::inside_bin_load_path(argv[i]);
             continue;
         }
-        else if(strcmp(argv[i],"-lp")==0 or strcmp(argv[i],"--install-libs-path")==0)
+        else if(strcmp(argv[i],"-dp")==0 or strcmp(argv[i],"--install-deps-path")==0)
         {
             i++;
-            Settings::inside_lib_load_path(argv[i]);
+            Settings::inside_dep_load_path(argv[i]);
             continue;
         }
         else if(strcmp(argv[i],"-i")==0 or strcmp(argv[i],"--ignore")==0)
@@ -157,9 +156,9 @@ int main (int argc, char * const argv[])
         }
     }
 
-    if (Settings::inside_lib_load_path() == "") {
-        // Default 'libs' load path to be equal to 'bin' load path for backward compatibility with older dylibbundler versions logic
-        Settings::inside_lib_load_path(Settings::inside_bin_load_path());
+    if (Settings::inside_dep_load_path() == "") {
+        // Default 'deps' load path to be equal to 'bin' load path for backward compatibility with older dylibbundler versions logic
+        Settings::inside_dep_load_path(Settings::inside_bin_load_path());
     }
     
     if(not Settings::bundleLibs() and Settings::fileToFixAmount()<1)


### PR DESCRIPTION
When playing with bundling complex application, I faced the challenge of patching several different binaries in several paths that need to refer the same 'libs' directory.

The challenge is that one should search for '../../libs', whle other - '../libs'.
The dependencies of binaries intersect, but are not entirely the same. When I patch the first binary, I still need to collect part of libraries for the second. Also, as libraries depend on each other, I need to use some 'stable' import path inside them to not be bound to the executable path.

The patch offers a way to solve the problem:
1. `--skip-existing` makes dylibbundler to use existing files inside `--dest-dir` and not patch them, allowing dylibbundler to patch libraries only once when executed for several binaries, adding only missing dependencies.
2. `--skip-patching` enables dylibbundler to iterate over dependencies and only bundle them into destination directory
3. `--skip-missing` enables dylibbundler to not fail or request interactive input for dependencies it cannot locate on FS (suitable for CI)
4. `--install-deps-path` makes dylibbundler to use different paths for `install_name_tool` when it patches the original file (`--fix-file) and its dependencies. The option defaults to `--install-path` value so the change is fully backward-compatible with previous logic of the tool.